### PR TITLE
Save config before closing the edit dialog

### DIFF
--- a/src/edit-widget.cpp
+++ b/src/edit-widget.cpp
@@ -198,6 +198,7 @@ public:
         {
             auto okbtn = new QPushButton(obs_module_text("OK"), this);
             QObject::connect(okbtn, &QPushButton::clicked, [this]() {
+                SaveConfig();
                 done(DialogCode::Accepted);
             });
             layout->addWidget(okbtn, currow, 0, 1, 2);


### PR DESCRIPTION
It looks like this was removed in an attempt to fix something else in commit 42b551d12c077f76d115169c10ba77052dc3ac68, but for me (I'm compiling from source to run it on Linux) it totally breaks the plug-in, because unless I change one of the combo boxes, the edit box no longer saves my settings, so I can't create any targets.

Putting this line alone back fixes the issue for me, but I'm not sure what dock issues were being fixed in the original commit, so I'm not sure if it breaks something else.

This is on the 0.2.7 tag, since I'm still on OBS v27.