### PR TITLE
Add support for SRT & RIST

### DIFF
--- a/src/push-widget.cpp
+++ b/src/push-widget.cpp
@@ -520,7 +520,7 @@ public:
     static const char *GetOutputID(const char *url) {
         if (strncmp("srt",  url,  3) == 0)  return "ffmpeg_mpegts_muxer";
         if (strncmp("rist", url,  4) == 0) return "ffmpeg_mpegts_muxer";
-        if (strncmp("hls", url,  3) == 0) return "ffmpeg_hls_muxer";
+
         return "rtmp_output";
     }
 

--- a/src/push-widget.cpp
+++ b/src/push-widget.cpp
@@ -517,6 +517,13 @@ public:
         ReleaseOutput();
     }
 
+    static const char *GetOutputID(const char *url) {
+        if (strncmp("srt",  url,  3) == 0)  return "ffmpeg_mpegts_muxer";
+        if (strncmp("rist", url,  4) == 0) return "ffmpeg_mpegts_muxer";
+        if (strncmp("hls", url,  3) == 0) return "ffmpeg_hls_muxer";
+        return "rtmp_output";
+    }
+
     void StartStreaming() override {
         if (IsRunning())
             return;
@@ -527,7 +534,11 @@ public:
         if (output_ == nullptr)
         {
             obs_data* output_settings = obs_data_create_from_json(config_->outputParam.dump().c_str());
-            output_ = obs_output_create("rtmp_output", "multi-output", output_settings, nullptr);
+            auto url = config_->serviceParam.at("server").template get<std::string>().c_str();
+            
+            blog(LOG_DEBUG, GetOutputID(url));
+
+            output_ = obs_output_create(GetOutputID(url), "multi-output", output_settings, nullptr);
             SetMeAsHandler(output_);
         }
 


### PR DESCRIPTION
After some time diving through the source code of the plugin and the internal OBS API, I found out that you can use different protocols by changing the [output](https://docs.obsproject.com/reference-outputs) ID.

This code selects the appropriate output ID depending on the stream URL.
More details in #386.

Tested RTMP and SRT with MediaMTX. SRT also works with srtreceive.
I haven't tested RIST yet. 
I saw that there is an HLS muxer, but I don't know if OBS can output it.

If code changes are needed, feel free to leave a feedback.

closes #3, 
closes #214, 
closes #386

possibly related to #389 