### PR TITLE
cmake: linux: sync with upstream plugin template

### DIFF
--- a/cmake/common/buildspec_common.cmake
+++ b/cmake/common/buildspec_common.cmake
@@ -87,7 +87,7 @@ function(_setup_obs_studio)
 
   message(STATUS "Build ${label} (${arch})")
   execute_process(
-    COMMAND "${CMAKE_COMMAND}" --build build_${arch} --target obs-frontend-api --config RelWithDebInfo --parallel
+    COMMAND "${CMAKE_COMMAND}" --build build_${arch} --target obs-frontend-api --config Debug --parallel
     WORKING_DIRECTORY "${dependencies_dir}/${_obs_destination}"
     RESULT_VARIABLE _process_result COMMAND_ERROR_IS_FATAL ANY
     OUTPUT_QUIET)
@@ -100,7 +100,7 @@ function(_setup_obs_studio)
     set(_cmake_extra "")
   endif()
   execute_process(
-    COMMAND "${CMAKE_COMMAND}" --install build_${arch} --component Development --config RelWithDebInfo --prefix
+    COMMAND "${CMAKE_COMMAND}" --install build_${arch} --component Development --config Debug --prefix
             "${dependencies_dir}" ${_cmake_extra}
     WORKING_DIRECTORY "${dependencies_dir}/${_obs_destination}"
     RESULT_VARIABLE _process_result COMMAND_ERROR_IS_FATAL ANY

--- a/cmake/linux/helpers.cmake
+++ b/cmake/linux/helpers.cmake
@@ -4,8 +4,6 @@ include_guard(GLOBAL)
 
 include(helpers_common)
 
-set(PLUGIN_FOLDER ${CMAKE_PROJECT_NAME})
-
 # set_target_properties_plugin: Set target properties for use in obs-studio
 function(set_target_properties_plugin target)
   set(options "")
@@ -26,23 +24,10 @@ function(set_target_properties_plugin target)
                SOVERSION ${PLUGIN_VERSION}
                PREFIX "")
 
-  # install(
-  #   TARGETS ${target}
-  #   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-  #   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/obs-plugins)
-
-  if (${CMAKE_SIZEOF_VOID_P} EQUAL 4)
-    set(OBSARCHNAME "32bit")
-  elseif (${CMAKE_SIZEOF_VOID_P} EQUAL 8)
-    set(OBSARCHNAME "64bit")
-  else ()
-    message(FATAL_ERROR "Unsupport architecture")
-  endif()
-
   install(
     TARGETS ${target}
-    RUNTIME DESTINATION dist/${PLUGIN_FOLDER}/bin/${OBSARCHNAME}
-    LIBRARY DESTINATION dist/${PLUGIN_FOLDER}/bin/${OBSARCHNAME})
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/obs-plugins)
 
   if(TARGET plugin-support)
     target_link_libraries(${target} PRIVATE plugin-support)
@@ -72,14 +57,9 @@ function(target_install_resources target)
       source_group("Resources/${relative_path}" FILES "${data_file}")
     endforeach()
 
-    # install(
-    #   DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/data/"
-    #   DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/obs/obs-plugins/${target}
-    #   USE_SOURCE_PERMISSIONS)
-    
     install(
       DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/data/"
-      DESTINATION dist/${PLUGIN_FOLDER}/data
+      DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/obs/obs-plugins/${target}
       USE_SOURCE_PERMISSIONS)
   endif()
 endfunction()
@@ -88,9 +68,7 @@ endfunction()
 function(target_add_resource target resource)
   message(DEBUG "Add resource '${resource}' to target ${target} at destination '${target_destination}'...")
 
-  # install(FILES "${resource}" DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/obs/obs-plugins/${target})
-
-  install(FILES "${resource}" DESTINATION dist/${PLUGIN_FOLDER}/data)
+  install(FILES "${resource}" DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/obs/obs-plugins/${target})
 
   source_group("Resources" FILES "${resource}")
 endfunction()


### PR DESCRIPTION
Hey,

When installing on linux, currently the project has things hard-coded in cmake to install to 
- `usr/dist/obs-multi-rtmp/data/locale` for the translation files
- `usr/dist/obs-multi-rtmp/bin/64bit/obs-multi-rtmp.so` for the shared library

Yet I want things to go to these two folders instead
- `usr/share/obs/obs-plugins/obs-multi-rtmp/locale/`
- `usr/lib64/obs-plugins/obs-multi-rtmp.so`

Unfortunately I cannot do anything about it except patching the cmake files: we can sync with the upstream code for the cmake files, and that gives variables we can use to tweak where files go:
- `CMAKE_INSTALL_BINDIR`
- `CMAKE_INSTALL_LIBDIR`
- `CMAKE_INSTALL_DATAROOTDIR`




