### PR TITLE
Fix crash when adding a new target with no protocol selected

### DIFF
--- a/src/output-config.h
+++ b/src/output-config.h
@@ -38,7 +38,7 @@ using AudioEncoderConfigPtr = std::shared_ptr<AudioEncoderConfig>;
 struct OutputTargetConfig {
     std::string id;
     std::string name;
-    std::string protocol;
+    std::string protocol = "RTMP";
     bool syncStart = false;
     bool syncStop = false;
 


### PR DESCRIPTION
OutputTargetConfig::protocol had no default member initializer, so a freshly created target (obs-multi-rtmp.cpp, "Add" button handler) starts with protocol == "". EditOutputWidgetImpl::updateServiceTab() looks this up via GetProtocolInfos()->GetInfo(), which returns nullptr for an empty string, and the following assert(protocol_info) aborts the process before the existing "fall back to first protocol" recovery path can run.

This didn't surface in release builds because CMake's default RelWithDebInfo flags define NDEBUG, compiling the assert out and silently taking the fallback branch instead. It reproduces reliably in any build where assertions stay enabled (e.g. distro packaging that manages its own optimization flags rather than relying on CMAKE_BUILD_TYPE).

Default protocol to "RTMP" so a new target is always constructed in a valid state, matching the "for compatibility" default already used when loading a config file (output-config.cpp: protocol.value_or("RTMP")).

Closes #583