### PR TITLE
update target environment to Visual Studio 2026 and toolset v145

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -59,12 +59,13 @@
         "lhs": "${hostSystemName}",
         "rhs": "Windows"
       },
-      "generator": "Visual Studio 17 2022",
+      "generator": "Visual Studio 18 2026",
+      "toolset": "v145",
       "architecture": "x64",
       "warnings": {"dev": true, "deprecated": true},
       "cacheVariables": {
         "QT_VERSION": "6",
-        "CMAKE_SYSTEM_VERSION": "10.0.18363.657",
+        "CMAKE_SYSTEM_VERSION": "10.0.26100.0",
         "CMAKE_INSTALL_PREFIX": "C:/ProgramData/obs-studio/plugins",
         "CMAKE_COMPILE_WARNING_AS_ERROR": false
       }


### PR DESCRIPTION
## 📝 Descrição
Esta PR atualiza as configurações de build do ambiente Windows para suportar o **Visual Studio 2026** e o toolset MSBuild **`v145`**, além de alinhar a versão do Windows SDK.

---

## 🔄 Alterações Realizadas
- **CMakePresets.json**:
  - Atualizado o gerador do preset `windows-x64` para `Visual Studio 18 2026`.
  - Definida a chave `"toolset": "v145"` para resolver o erro de versão do compiltador.
  - Atualizado o `CMAKE_SYSTEM_VERSION` para `10.0.26100.0` (Windows SDK 11).

---

## 🧪 Como Testar
1. Limpe a pasta de build anterior (ex: `build_x64`).
2. Execute o comando de configuração do CMake apontando para o preset `windows-x64`:
   ```bash
   cmake --preset windows-x64